### PR TITLE
refactor: refactor CalculatorItemQueue, separate CalculateItem

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		18DDB22328D857DF006568AD /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DDB22228D857DF006568AD /* CalculatorItemQueue.swift */; };
 		18EB9AE228E5418500FFF5D8 /* CalculatedLogStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EB9AE128E5418500FFF5D8 /* CalculatedLogStackView.swift */; };
 		18EB9AE428E58E4900FFF5D8 /* ScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EB9AE328E58E4900FFF5D8 /* ScrollView+.swift */; };
+		6949E4AC28EB118200937510 /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6949E4AB28EB118200937510 /* CalculateItem.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* CalculatorViewController.swift */; };
 		C713D9492570E5EB001C3AFC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C713D9472570E5EB001C3AFC /* Main.storyboard */; };
@@ -55,6 +56,7 @@
 		18DDB22228D857DF006568AD /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		18EB9AE128E5418500FFF5D8 /* CalculatedLogStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatedLogStackView.swift; sourceTree = "<group>"; };
 		18EB9AE328E58E4900FFF5D8 /* ScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScrollView+.swift"; sourceTree = "<group>"; };
+		6949E4AB28EB118200937510 /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				18CFA3C528DC43A8004747CE /* Operator.swift */,
 				18CFA3E928DC5F98004747CE /* Formula.swift */,
 				1830C26B28DFD1C1009AFA5F /* ExpressionParser.swift */,
+				6949E4AB28EB118200937510 /* CalculateItem.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 				18CFA3C628DC43A8004747CE /* Operator.swift in Sources */,
 				18CFA3E628DC5999004747CE /* FormulaError.swift in Sources */,
 				1839CDE028E5C92C00885ADD /* Constants.swift in Sources */,
+				6949E4AC28EB118200937510 /* CalculateItem.swift in Sources */,
 				18CFA3EA28DC5F98004747CE /* Formula.swift in Sources */,
 				1830C26C28DFD1C1009AFA5F /* ExpressionParser.swift in Sources */,
 			);

--- a/Calculator/Calculator/Sources/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Sources/Calculator/Model/CalculateItem.swift
@@ -1,0 +1,8 @@
+//
+//  CalculateItem.swift
+//  Calculator
+//
+//  Created by SummerCat on 2022/10/03.
+//
+
+protocol CalculateItem { }

--- a/Calculator/Calculator/Sources/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Sources/Calculator/Model/CalculatorItemQueue.swift
@@ -3,22 +3,12 @@
 //  Created by 미니.
 //
 
-protocol CalculateItem { }
-
 struct CalculatorItemQueue<Element: CalculateItem> {
     private var inputStack: [Element] = []
     private var outputStack: [Element] = []
     
-    var isEmpty: Bool {
+    private(set) var isEmpty: Bool {
         return inputStack.isEmpty && outputStack.isEmpty
-    }
-    
-    var front: Element? {
-        return outputStack.last ?? inputStack.first
-    }
-    
-    var count: Int {
-        return outputStack.count + inputStack.count
     }
     
     init(elements: [Element] = []) {
@@ -28,8 +18,7 @@ struct CalculatorItemQueue<Element: CalculateItem> {
     mutating func enqueue(_ element: Element) {
         inputStack.append(element)
     }
-    
-    @discardableResult
+
     mutating func dequeue() -> Element? {
         if outputStack.isEmpty {
             outputStack = inputStack.reversed()


### PR DESCRIPTION
- CalculatorItemQueue 내 프로퍼티/메서드 중 사용하지 않는 메서드 삭제, `isEmpty` 접근 제어 레벨 수정
- CalculateItem 프로토콜 CalculatorItemQueue에서 분리하여 별도 파일로 작성